### PR TITLE
Fixed compilation errors on latest version of rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 typenum = "1.0.0"
-spin = "0.4.0"
+spin = "0.9.8"
 
 [dev-dependencies]
 jemallocator = { version = "^0.1.0", features = ["alloc_trait"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -160,7 +160,7 @@ where
 
         // Pad the layout to the minimum legal size
         let block_layout = {
-            let mut size = max(HeapBlock::<BS>::min_size(), layout.size());
+            let size = max(HeapBlock::<BS>::min_size(), layout.size());
             Layout::from_size_align_unchecked(align_up(size, align_of::<Hole>()), layout.align())
         };
 

--- a/src/hole.rs
+++ b/src/hole.rs
@@ -3,7 +3,7 @@
 //! Adapted from [`linked_list_allocator`](https://github.com/phil-opp/linked-list-allocator)
 //! to work with several linked blocks instead of a single one.
 
-use core::alloc::AllocErr;
+use core::alloc::AllocError;
 use core::alloc::Layout;
 use core::marker::PhantomData;
 use core::mem::size_of;
@@ -62,7 +62,7 @@ where
     ///
     /// This function uses the “first fit” strategy, so it uses the first hole that is big
     /// enough. Thus the runtime is in O(n) but it should be reasonably fast for small allocations.
-    pub fn allocate_first_fit(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
+    pub fn allocate_first_fit(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         assert!(layout.size() >= Self::min_size());
 
         allocate_first_fit(&mut self.first, layout).map(|allocation| {
@@ -199,7 +199,7 @@ fn split_hole(hole: HoleInfo, required_layout: Layout) -> Option<Allocation> {
 /// care of freeing it again.
 /// This function uses the “first fit” strategy, so it breaks as soon as a big enough hole is
 /// found (and returns it).
-fn allocate_first_fit(mut previous: &mut Hole, layout: Layout) -> Result<Allocation, AllocErr> {
+fn allocate_first_fit(mut previous: &mut Hole, layout: Layout) -> Result<Allocation, AllocError> {
     loop {
         let allocation: Option<Allocation> = previous
             .next
@@ -217,7 +217,7 @@ fn allocate_first_fit(mut previous: &mut Hole, layout: Layout) -> Result<Allocat
             }
             None => {
                 // this was the last hole, so no hole is big enough -> allocation not possible
-                return Err(AllocErr);
+                return Err(AllocError);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,8 +95,8 @@
 
 #![cfg_attr(not(test), no_std)]
 #![feature(allocator_api)]
-#![feature(const_fn)]
 #![feature(alloc_layout_extra)]
+#![feature(const_mut_refs)]
 
 #[cfg(test)]
 use std as core;


### PR DESCRIPTION
- Removed feature flag for `const_fn`, since it is no longer needed
- Added `const_mut_refs` feature flag
- Changed `AllocErr` to `AllocError`
- Updated to latest version of `spin-rs`
- Added `rust-toolchain.toml` file to ensure the code is always compiled using nightly rust